### PR TITLE
Rename swagger docs endpoint

### DIFF
--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -54,7 +54,7 @@ app = FastAPI(
     title=settings.name,
     version=tipg_version,
     openapi_url="/api",
-    docs_url="/api.html",
+    docs_url="/docs",
     lifespan=lifespan,
     root_path=settings.root_path,
 )


### PR DESCRIPTION
To maintain consistency across all deployed APIs, the swagger docs endpoint has been renamed to `/docs`.

Once this change is deployed, the new swagger docs should be accessible through: `<URL>/api/features/docs`