### PR TITLE
Add support for RDS proxy

### DIFF
--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
 RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] -t /asset --no-binary pydantic
+RUN pip install pygeofilter -t /asset
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
 RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] -t /asset --no-binary pydantic
-RUN pip install pygeofilter -t /asset
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -275,3 +275,9 @@ class FeaturesRdsConstruct(Construct):
             export_name=f"{stack_name}-featuresdb-secret-name",
             description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} postgres database",
         )
+        if self.proxy:
+            CfnOutput(
+                self,
+                "rds-proxy-endpoint",
+                value=self.proxy.endpoint
+            )

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -224,7 +224,7 @@ class FeaturesRdsConstruct(Construct):
         if features_db_settings.use_rds_proxy:
             proxy_secret = self.postgis.secret
             
-            ##create a proxy role
+            ## create a proxy role
             proxy_role = aws_iam.Role(
                 self,
                 "RDSProxyRole",
@@ -264,7 +264,7 @@ class FeaturesRdsConstruct(Construct):
                     "username": SecretValue.unsafe_plain_text(features_db_settings.user),
                     # Here we use the same password we bootstrapped for pgstac to avoid creating a new user
                     # for the proxy
-                    "password": self.pgstac.secret.secret_value_from_json("password"),
+                    "password": self.postgis.secret.secret_value_from_json("password"),
                 }
             )
         


### PR DESCRIPTION
This PR adds support for RDS proxy. Use `USE_RDS_PROXY=True` as environment variable to enable creation of proxy. 