### PR TITLE
Tag subnets for MWAA

### DIFF
--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -14,6 +14,7 @@ from aws_cdk import (
     aws_logs,
     aws_rds,
     aws_secretsmanager,
+    Tags
 )
 from constructs import Construct
 
@@ -166,6 +167,10 @@ class FeaturesRdsConstruct(Construct):
                 else aws_ec2.SubnetType.PUBLIC
             )
             self.vpc_subnets = aws_ec2.SubnetSelection(subnet_type=subnet_type)
+
+        # Make sure private subnets that are either existing or newly created have appropriate
+        # tags for MWAA to query and then tell ECS tasks where they need to run
+        Tags.of(self.vpc_subnets).add('Scope', 'private');
 
         # Database Configurations
         database_config = {


### PR DESCRIPTION
For EIS VEDA `dev` and `staging` MWAA environments we need to make sure we tag existing or private subnets in the target VPC so MWAA can inform vector ECS task during ingestion where to appropriately run and have access to the DB 