### PR TITLE
fix(db): support restoring from encrypted rds snapshot

### DIFF
--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -185,7 +185,7 @@ class FeaturesRdsConstruct(Construct):
 
         # Only set storage_encrypted if creating a database instance not from snapshot. Use an encrypted snapshot when creating a new encrypted database from a snapshot.
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstanceFromSnapshot.html
-        if not features_db_settings.snapshot_i and features_db_settings.rds_encryption:
+        if not features_db_settings.snapshot_id and features_db_settings.rds_encryption:
             database_config["storage_encrypted"] = features_db_settings.rds_encryption
 
         # Create a new database instance from snapshot if provided

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -183,7 +183,9 @@ class FeaturesRdsConstruct(Construct):
             "parameter_group": parameter_group,
         }
 
-        if features_db_settings.rds_encryption:
+        # Only set storage_encrypted if creating a database instance not from snapshot. Use an encrypted snapshot when creating a new encrypted database from a snapshot.
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstanceFromSnapshot.html
+        if not features_db_settings.snapshot_i and features_db_settings.rds_encryption:
             database_config["storage_encrypted"] = features_db_settings.rds_encryption
 
         # Create a new database instance from snapshot if provided


### PR DESCRIPTION
## What
Minor change to support using an encrypted snapshot of a database (the `storage_encrypted` parameter is not allowed when restoring from a snapshot id).

## Git issue
https://github.com/NASA-IMPACT/veda-deploy/issues/70

## How tested
Deployed using an encrypted snapshot and confirmed that the new instance is encrypted.