### PR TITLE
Fix(api): remove base path parameter from handler

### DIFF
--- a/features_api/runtime/handler.py
+++ b/features_api/runtime/handler.py
@@ -11,7 +11,7 @@ from src.monitoring import logger, metrics, tracer
 logging.getLogger("mangum.lifespan").setLevel(logging.DEBUG)
 logging.getLogger("mangum.http").setLevel(logging.DEBUG)
 
-handler = Mangum(app, lifespan="auto")
+handler = Mangum(app, lifespan="on")
 
 if "AWS_EXECUTION_ENV" in os.environ:
     loop = asyncio.get_event_loop()

--- a/features_api/runtime/handler.py
+++ b/features_api/runtime/handler.py
@@ -11,7 +11,7 @@ from src.monitoring import logger, metrics, tracer
 logging.getLogger("mangum.lifespan").setLevel(logging.DEBUG)
 logging.getLogger("mangum.http").setLevel(logging.DEBUG)
 
-handler = Mangum(app, lifespan="on", api_gateway_base_path=app.root_path)
+handler = Mangum(app, lifespan="auto")
 
 if "AWS_EXECUTION_ENV" in os.environ:
     loop = asyncio.get_event_loop()

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -108,6 +108,14 @@ def ping():
 @app.get("/refresh")
 async def refresh(request: Request):
     """refresh catalog"""
+    
+    await connect_to_db(
+        app,
+        settings=postgres_settings,
+        schemas=[
+            "public",
+        ],
+    )
     await register_collection_catalog(
         request.app,
         schemas=db_settings.schemas,

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -109,13 +109,6 @@ def ping():
 async def refresh(request: Request):
     """refresh catalog"""
     
-    await connect_to_db(
-        app,
-        settings=postgres_settings,
-        schemas=[
-            "public",
-        ],
-    )
     await register_collection_catalog(
         request.app,
         schemas=db_settings.schemas,


### PR DESCRIPTION
## What
- Remove base path from mangum handler

## Why
- Corrects a behavior in which a trailing path was required to reach the API

## How tested
- Deployed to smce-staging and confirmed API could be reached without adding a trailing slash