### PR TITLE
fix: update workflows to use full commit hash

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -15,9 +15,9 @@ runs:
   using: "composite"
   steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: '3.9'
         cache: 'pip'
@@ -25,11 +25,11 @@ runs:
           ${{ inputs.dir }}/requirements.txt
 
     - name: Setup Node
-      uses: actions/setup-node@v4
-      with: 
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e4 #v4.3.0
+      with:
         node-version: 20
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: npm install -g aws-cdk@2
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ env.pythonLocation }}
         key:  ${{ env.pythonLocation }}-${{ hashFiles('${{ inputs.dir }}/requirements.txt') }}


### PR DESCRIPTION
Relevant issue: https://github.com/NASA-IMPACT/veda-architecture/issues/569

- actions/checkout@v4 pinned to [v4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683)
- actions/setup-python@v5 pinned to [v.5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)
- actions/setup-node@v4 pinned to [v4.3.0](https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e)
- actions/cache@v4 pinned to [v4.2.2](https://github.com/actions/cache/commit/d4323d4df104b026a6aa633fdb11d772146be0bf)