### PR TITLE
feat: add db configuration

### DIFF
--- a/features_api_database/infrastructure/config.py
+++ b/features_api_database/infrastructure/config.py
@@ -39,7 +39,7 @@ class FeaturesDBSettings(BaseSettings):
     )
     # RDS custom postgres parameters
     max_locks_per_transaction: Optional[str] = Field(
-        "1024",
+        "64",
         description="Number of database objects that can be locked simultaneously",
         pattern=r"^[1-9]\d*$",
     )
@@ -61,6 +61,11 @@ class FeaturesDBSettings(BaseSettings):
     use_rds_proxy: Optional[bool] = Field(
         False,
         description="Boolean if the RDS should be accessed through a proxy",
+    )
+    random_page_cost: Optional[str] = Field(
+        "1.1",
+        description="Sets the estimate of the cost of a non-sequentially fetched disk page. This parameter has no value unless query plan management (QPM) is turned on. When QPM is on, the default value for this parameter 4.",
+        pattern=r"^[1-9]\d*.[1-9]",
     )
     rds_instance_class: Optional[str] = Field(
         aws_ec2.InstanceClass.BURSTABLE3.value,
@@ -94,7 +99,10 @@ class FeaturesDBSettings(BaseSettings):
         False,
         description="Boolean if the RDS should be encrypted",
     )
-
+    max_allocated_storage: Optional[int] = Field(
+        500,
+        description="Upper limit to which RDS can scale the storage in GiB(Gibibyte)",
+    )
 
     @validator("rds_instance_class", pre=True, always=True)
     def convert_rds_class_to_uppercase(cls, value):


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-features-api-cdk/issues/32
Env variables and cdk construct updates to support setting:

- RDS Configs
  - storage autoscaling and maximum storage threshold (we used 500 GB)

[RDS Params](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Parameters.html)
- random_page_cost (we used 1.1)
- change default max_locks_per_transaction to 64

<img width="1435" alt="Screenshot 2025-06-26 at 1 25 33 PM" src="https://github.com/user-attachments/assets/a34ec29e-8f43-452b-8b8f-801ccb464ac3" />
fd3-a472-28c16e1496fe" />
<img width="1440" alt="Screenshot 2025-06-26 at 1 23 19 PM" src="https://github.com/user-attachments/assets/8d21d308-bfda-4731-b8f1-904e902f8f39" />
<img width="1448" alt="Screenshot 2025-06-26 at 1 25 14 PM" src="https://github.com/user-attachments/assets/a12bbc2c-52a6-453e-9510-e5b8fc4e5122" />

