### PR TITLE
feat: update construct to add inbound security group rules for airflow workers

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,4 +1,9 @@
+STAGE=***
 VPC_ID=***
+
+VEDA_FEATURES_DB_SCHEMA_VERSION=x.y.z
+VEDA_FEATURES_DB_AIRFLOW_WORKER_SECURITY_GROUPS=["sg-airflow-worker", "sg-airflow-worker"]
+
+# Optional but recommended
 CDK_DEFAULT_ACCOUNT=***
 CDK_DEFAULT_REGION=***
-STAGE=***

--- a/features_api/infrastructure/construct.py
+++ b/features_api/infrastructure/construct.py
@@ -73,7 +73,7 @@ class FeaturesAPILambdaConstruct(Construct):
         features_api_function.add_environment(
             "VEDA_FEATURES_ROOT_PATH", features_lambda_settings.features_root_path
         )
-        
+
         features_api_function.add_environment(
             "VEDA_FEATURES_STAGE", stage
         )

--- a/features_api_database/infrastructure/config.py
+++ b/features_api_database/infrastructure/config.py
@@ -21,6 +21,10 @@ class FeaturesDBSettings(BaseSettings):
         "veda",
         description="Name of pgstac role for postgres database",
     )
+    table_loader_user: Optional[str] = Field(
+        "veda_table_loader",
+        description="Name of table loader role for postgres database with permissions for data ingestion",
+    )
     schema_version: str = Field(
         ...,
         description=(

--- a/features_api_database/infrastructure/config.py
+++ b/features_api_database/infrastructure/config.py
@@ -1,5 +1,5 @@
 """Veda-backend database construct configuration."""
-from typing import Optional
+from typing import Optional, List
 
 from aws_cdk import aws_ec2, aws_rds
 from pydantic import Field, validator
@@ -20,10 +20,6 @@ class FeaturesDBSettings(BaseSettings):
     user: str = Field(
         "veda",
         description="Name of pgstac role for postgres database",
-    )
-    table_loader_user: Optional[str] = Field(
-        "veda_table_loader",
-        description="Name of table loader role for postgres database with permissions for data ingestion",
     )
     schema_version: str = Field(
         ...,
@@ -106,6 +102,10 @@ class FeaturesDBSettings(BaseSettings):
     max_allocated_storage: Optional[int] = Field(
         500,
         description="Upper limit to which RDS can scale the storage in GiB(Gibibyte)",
+    )
+    airflow_worker_security_groups: Optional[List[str]] = Field(
+        [],
+        description="Security group IDs for airflow workers to access RDS",
     )
 
     @validator("rds_instance_class", pre=True, always=True)

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -76,9 +76,31 @@ class BootstrapTIPG(Construct):
             description=f"TIPG database bootsrapped by {Stack.of(self).stack_name} stack",
         )
 
+        self.table_loader_secret = aws_secretsmanager.Secret(
+            self,
+            "table-loader-secret",
+            secret_name=os.path.join(secrets_prefix, construct_id, "table-loader", self.node.addr[-8:]),
+            generate_secret_string=aws_secretsmanager.SecretStringGenerator(
+                secret_string_template=json.dumps(
+                    {
+                        "dbname": new_dbname,
+                        "engine": "postgres",
+                        "port": 5432,
+                        "host": host,
+                        "username": new_username,
+                    }
+                ),
+                generate_string_key="password",
+                exclude_punctuation=True,
+            ),
+            description=f"Table loader databaser user with permissions for data ingestion by {Stack.of(self).stack_name} stack",
+        )
+
         # Allow lambda to...
         # read new user secret
         self.secret.grant_read(handler)
+        # read table loader user secret
+        self.table_loader_secret.grant_read(handler)
         # read database secret
         database.secret.grant_read(handler)
         # connect to database
@@ -93,6 +115,7 @@ class BootstrapTIPG(Construct):
             properties={
                 "conn_secret_arn": database.secret.secret_arn,
                 "new_user_secret_arn": self.secret.secret_arn,
+                "table_loader_user_secret_arn": self.table_loader_secret.secret_arn,
                 # property to update the lambda that triggers bootstrapping
                 # check here: https://stackoverflow.com/a/74727589
                 "database_schema_version": database_schema_version,
@@ -250,7 +273,7 @@ class FeaturesRdsConstruct(Construct):
                 debug_logging=False
             )
 
-            ## allow connections to the proxy frmo the same security group as DB
+            ## allow connections to the proxy from the same security group as DB
             for sg in database.connections.security_groups:
                 self.proxy.connections.add_security_group(sg)
 
@@ -274,12 +297,37 @@ class FeaturesRdsConstruct(Construct):
                 }
             )
 
+            self.postgis.table_loader_secret = aws_secretsmanager.Secret(
+                self,
+                "RDSProxyTableLoaderSecret",
+                secret_name=os.path.join(
+                    stack_name, f"veda-features-api-{stage}/db-ingest/rds-proxy", self.node.addr[-8:]
+                ),
+                description="Features API RDS Proxy Secrets for Airflow ingests",
+                secret_object_value = {
+                    "dbname": SecretValue.unsafe_plain_text(features_db_settings.dbname),
+                    "engine": SecretValue.unsafe_plain_text("postgres"),
+                    "port": SecretValue.unsafe_plain_text("5432"),
+                    "host": SecretValue.unsafe_plain_text(self.proxy.endpoint),
+                    "username": SecretValue.unsafe_plain_text(features_db_settings.table_loader_user),
+                    "password": self.postgis.table_loader_secret.secret_value_from_json("password"),
+                }
+            )
+
         CfnOutput(
             self,
             "featuresdb-secret-name",
             value=self.postgis.secret.secret_arn,
             export_name=f"{stack_name}-featuresdb-secret-name",
             description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} postgres database",
+        )
+
+        CfnOutput(
+            self,
+            "table-loader-secret-name",
+            value=self.postgis.table_loader_secret.secret_arn,
+            export_name=f"{stack_name}-table-loader-secret-name",
+            description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} table loader",
         )
         if self.proxy:
             CfnOutput(

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -73,13 +73,13 @@ class BootstrapTIPG(Construct):
                 generate_string_key="password",
                 exclude_punctuation=True,
             ),
-            description=f"TIPG database bootsrapped by {Stack.of(self).stack_name} stack",
+            description=f"TIPG database bootstrapped by {Stack.of(self).stack_name} stack",
         )
 
         self.table_loader_secret = aws_secretsmanager.Secret(
             self,
             "table-loader-secret",
-            secret_name=os.path.join(secrets_prefix, construct_id, "table-loader", self.node.addr[-8:]),
+            secret_name=os.path.join(secrets_prefix, construct_id, "table-loader-secret", self.node.addr[-8:]),
             generate_secret_string=aws_secretsmanager.SecretStringGenerator(
                 secret_string_template=json.dumps(
                     {
@@ -87,7 +87,7 @@ class BootstrapTIPG(Construct):
                         "engine": "postgres",
                         "port": 5432,
                         "host": host,
-                        "username": new_username,
+                        "username": features_db_settings.table_loader_user,
                     }
                 ),
                 generate_string_key="password",
@@ -252,6 +252,7 @@ class FeaturesRdsConstruct(Construct):
         self.proxy = None
         if features_db_settings.use_rds_proxy:
             proxy_secret = self.postgis.secret
+            table_loader_proxy_secret = self.postgis.table_loader_secret
 
             ## create a proxy role
             proxy_role = aws_iam.Role(
@@ -266,7 +267,7 @@ class FeaturesRdsConstruct(Construct):
                 proxy_target=aws_rds.ProxyTarget.from_instance(database),
                 id="RdsProxy",
                 vpc=vpc,
-                secrets=[database.secret, proxy_secret],
+                secrets=[database.secret, proxy_secret, table_loader_proxy_secret],
                 db_proxy_name=f"{stack_name}-proxy",
                 role=proxy_role,
                 require_tls=False,
@@ -329,6 +330,7 @@ class FeaturesRdsConstruct(Construct):
             export_name=f"{stack_name}-table-loader-secret-name",
             description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} table loader",
         )
+
         if self.proxy:
             CfnOutput(
                 self,

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -76,37 +76,17 @@ class BootstrapTIPG(Construct):
             description=f"TIPG database bootstrapped by {Stack.of(self).stack_name} stack",
         )
 
-        self.table_loader_secret = aws_secretsmanager.Secret(
-            self,
-            "table-loader-secret",
-            secret_name=os.path.join(secrets_prefix, construct_id, "table-loader-secret", self.node.addr[-8:]),
-            generate_secret_string=aws_secretsmanager.SecretStringGenerator(
-                secret_string_template=json.dumps(
-                    {
-                        "dbname": new_dbname,
-                        "engine": "postgres",
-                        "port": 5432,
-                        "host": host,
-                        "username": features_db_settings.table_loader_user,
-                    }
-                ),
-                generate_string_key="password",
-                exclude_punctuation=True,
-            ),
-            description=f"Table loader databaser user with permissions for data ingestion by {Stack.of(self).stack_name} stack",
-        )
-
         # Allow lambda to...
         # read new user secret
         self.secret.grant_read(handler)
-        # read table loader user secret
-        self.table_loader_secret.grant_read(handler)
         # read database secret
         database.secret.grant_read(handler)
         # connect to database
         database.connections.allow_from(handler, port_range=aws_ec2.Port.tcp(5432))
 
         self.connections = database.connections
+
+
 
         CustomResource(
             scope=scope,
@@ -115,7 +95,6 @@ class BootstrapTIPG(Construct):
             properties={
                 "conn_secret_arn": database.secret.secret_arn,
                 "new_user_secret_arn": self.secret.secret_arn,
-                "table_loader_user_secret_arn": self.table_loader_secret.secret_arn,
                 # property to update the lambda that triggers bootstrapping
                 # check here: https://stackoverflow.com/a/74727589
                 "database_schema_version": database_schema_version,
@@ -221,7 +200,6 @@ class FeaturesRdsConstruct(Construct):
             snapshot_credentials = aws_rds.SnapshotCredentials.from_generated_secret(
                 username=features_db_settings.admin_user
             )
-
             database = aws_rds.DatabaseInstanceFromSnapshot(
                 self,
                 snapshot_identifier=features_db_settings.snapshot_id,
@@ -252,7 +230,6 @@ class FeaturesRdsConstruct(Construct):
         self.proxy = None
         if features_db_settings.use_rds_proxy:
             proxy_secret = self.postgis.secret
-            table_loader_proxy_secret = self.postgis.table_loader_secret
 
             ## create a proxy role
             proxy_role = aws_iam.Role(
@@ -267,7 +244,7 @@ class FeaturesRdsConstruct(Construct):
                 proxy_target=aws_rds.ProxyTarget.from_instance(database),
                 id="RdsProxy",
                 vpc=vpc,
-                secrets=[database.secret, proxy_secret, table_loader_proxy_secret],
+                secrets=[database.secret, proxy_secret],
                 db_proxy_name=f"{stack_name}-proxy",
                 role=proxy_role,
                 require_tls=False,
@@ -277,6 +254,19 @@ class FeaturesRdsConstruct(Construct):
             ## allow connections to the proxy from the same security group as DB
             for sg in database.connections.security_groups:
                 self.proxy.connections.add_security_group(sg)
+
+            if features_db_settings.airflow_worker_security_groups:
+                for sg in features_db_settings.airflow_worker_security_groups:
+                    try:
+                        self.proxy.connections.add_security_group(
+                            aws_ec2.SecurityGroup.from_security_group_id(
+                                self,
+                                f"AirflowWorkerSecurityGroup-{sg}",
+                                sg,
+                            )
+                        )
+                    except Exception as e:
+                        print(f"Warning: Could not add security group {sg}: {e}")
 
             ## update value of host to use proxy endpoint
             self.postgis.secret = aws_secretsmanager.Secret(
@@ -298,22 +288,6 @@ class FeaturesRdsConstruct(Construct):
                 }
             )
 
-            self.postgis.table_loader_secret = aws_secretsmanager.Secret(
-                self,
-                "RDSProxyTableLoaderSecret",
-                secret_name=os.path.join(
-                    stack_name, f"veda-features-api-{stage}/db-ingest/rds-proxy", self.node.addr[-8:]
-                ),
-                description="Features API RDS Proxy Secrets for Airflow ingests",
-                secret_object_value = {
-                    "dbname": SecretValue.unsafe_plain_text(features_db_settings.dbname),
-                    "engine": SecretValue.unsafe_plain_text("postgres"),
-                    "port": SecretValue.unsafe_plain_text("5432"),
-                    "host": SecretValue.unsafe_plain_text(self.proxy.endpoint),
-                    "username": SecretValue.unsafe_plain_text(features_db_settings.table_loader_user),
-                    "password": self.postgis.table_loader_secret.secret_value_from_json("password"),
-                }
-            )
 
         CfnOutput(
             self,
@@ -321,14 +295,6 @@ class FeaturesRdsConstruct(Construct):
             value=self.postgis.secret.secret_arn,
             export_name=f"{stack_name}-featuresdb-secret-name",
             description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} postgres database",
-        )
-
-        CfnOutput(
-            self,
-            "table-loader-secret-name",
-            value=self.postgis.table_loader_secret.secret_arn,
-            export_name=f"{stack_name}-table-loader-secret-name",
-            description=f"Name of the Secrets Manager instance holding the connection info for the {construct_id} table loader",
         )
 
         if self.proxy:

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -72,39 +72,79 @@ def get_secret(secret_name):
 
 def create_db(cursor, db_name: str) -> None:
     """Create DB."""
-    cursor.execute(
-        sql.SQL("SELECT 1 FROM pg_catalog.pg_database " "WHERE datname = %s"), [db_name]
-    )
-    if cursor.fetchone():
-        print(f"database {db_name} exists, not creating DB")
-    else:
-        print(f"database {db_name} not found, creating...")
-        cursor.execute(
-            sql.SQL("CREATE DATABASE {db_name}").format(db_name=sql.Identifier(db_name))
-        )
+    print(f"DEBUG: create_db called with db_name='{db_name}'")
+
+    try:
+        cursor.execute("SELECT datname FROM pg_catalog.pg_database ORDER BY datname")
+        existing_dbs = [row[0] for row in cursor.fetchall()]
+
+        print(f"DEBUG: Existing databases: {existing_dbs}")
+
+        if db_name in existing_dbs:
+            print(f"DEBUG: Database '{db_name}' already exists")
+        else:
+            print(f"DEBUG: Database '{db_name}' not found, creating...")
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name))
+            )
+            print(f"DEBUG: Database '{db_name}' created successfully")
+
+            cursor.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname = %s", [db_name])
+            if cursor.fetchone():
+                print(f"DEBUG: Database '{db_name}' exists after creation")
+            else:
+                print(f"DEBUG: Database '{db_name}' was NOT created successfully")
+
+    except Exception as e:
+        print(f"ERROR: create_db failed: {e}")
+        raise
 
 
 def create_user(cursor, username: str, password: str) -> None:
     """Create User."""
 
-    cursor.execute(
-        sql.SQL(
-            "DO $$ "
-            "BEGIN "
-            "  IF NOT EXISTS ( "
-            "       SELECT 1 FROM pg_roles "
-            "       WHERE rolname = {user}) "
-            "  THEN "
-            "    CREATE USER {username} "
-            "    WITH PASSWORD {password}; "
-            "  ELSE "
-            "    ALTER USER {username} "
-            "    WITH PASSWORD {password}; "
-            "  END IF; "
-            "END "
-            "$$; "
-        ).format(username=sql.Identifier(username), password=password, user=username)
-    )
+    print(f"DEBUG: create_user called with username='{username}'")
+
+    try:
+        # Check if user exists before
+        cursor.execute("SELECT rolname FROM pg_roles WHERE rolname = %s", (username,))
+        exists_before = cursor.fetchone() is not None
+        print(f"DEBUG: User '{username}' exists before: {exists_before}")
+
+        # Create/update user
+        cursor.execute(
+            sql.SQL(
+                "DO $$ "
+                "BEGIN "
+                "  IF NOT EXISTS ( "
+                "       SELECT 1 FROM pg_roles "
+                "       WHERE rolname = {user}) "
+                "  THEN "
+                "    CREATE USER {username} "
+                "    WITH PASSWORD {password}; "
+                "  ELSE "
+                "    ALTER USER {username} "
+                "    WITH PASSWORD {password}; "
+                "  END IF; "
+                "END "
+                "$$; "
+            ).format(username=sql.Identifier(username), password=password, user=username)
+        )
+        print(f"DEBUG: SQL executed successfully")
+
+        # Check if user exists after
+        cursor.execute("SELECT rolname FROM pg_roles WHERE rolname = %s", (username,))
+        exists_after = cursor.fetchone() is not None
+        print(f"DEBUG: User '{username}' exists after: {exists_after}")
+
+        if exists_after:
+            print(f"DEBUG: User '{username}' created/updated successfully")
+        else:
+            print(f"DEBUG: User '{username}' was NOT created")
+
+    except Exception as e:
+        print(f"ERROR: create_user failed: {e}")
+        raise
 
 
 def create_permissions(cursor, db_name: str, username: str) -> None:
@@ -118,42 +158,6 @@ def create_permissions(cursor, db_name: str, username: str) -> None:
             "GRANT ALL PRIVILEGES ON TABLES TO {username};"
             "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
             "GRANT ALL PRIVILEGES ON SEQUENCES TO {username};"
-        ).format(
-            db_name=sql.Identifier(db_name),
-            username=sql.Identifier(username),
-        )
-    )
-
-def create_table_loader_admin_permissions(cursor, db_name: str, username:str) -> None:
-    """Add admin permissions to the user to enable table editing for data ingestion"""
-    cursor.execute(
-        sql.SQL(
-            "GRANT CONNECT ON DATABASE {db_name} TO {username};"
-            "GRANT CREATE ON DATABASE {db_name} TO {username};"
-            "GRANT TEMPORARY ON DATABASE {db_name} TO {username};"
-
-            # Allow table and sequence creation and editing for future objects
-            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {username};"
-            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {username};"
-            "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO {username};"
-
-            # Allow schema creation
-            "GRANT USAGE ON SCHEMA public TO {username};"
-            "GRANT CREATE ON SCHEMA public TO {username};"
-
-            # Allow table creation and editing
-            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-            "GRANT ALL PRIVILEGES ON TABLES TO {username};"
-
-            # Allow sequence creation and editing
-            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
-            "GRANT ALL PRIVILEGES ON SEQUENCES TO {username};"
-
-            # Allows core data manipulation permissions on all existing tables with
-            # privileges to add data (insert), modify data (update), remove data (delete),
-            # and read data (select)
-            "GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA public TO {username};"
-            "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {username};"
         ).format(
             db_name=sql.Identifier(db_name),
             username=sql.Identifier(username),
@@ -188,9 +192,9 @@ def handler(event, context):
         params = event["ResourceProperties"]
         connection_params = get_secret(params["conn_secret_arn"])
         user_params = get_secret(params["new_user_secret_arn"])
-        table_loader_params = get_secret(params["table_loader_user_secret_arn"])
 
         print("Connecting to admin DB...")
+        print(f"DEBUG: admin dbname")
         admin_db_conninfo = make_conninfo(
             dbname=connection_params.get("dbname", "postgres"),
             user=connection_params["username"],
@@ -218,22 +222,6 @@ def handler(event, context):
                     cursor=cur,
                     db_name=user_params["dbname"],
                     username=user_params["username"],
-                )
-
-                print("Creating admin user for table editing...")
-                print(f"Creating user: {table_loader_params['username']}")
-                create_user(
-                    cursor=cur,
-                    username=table_loader_params["username"],
-                    password=table_loader_params["password"],
-                )
-
-                print("Setting admin permissions...")
-                print(f"Setting permissions for table loader user: {table_loader_params['username']}")
-                create_table_loader_admin_permissions(
-                    cursor=cur,
-                    db_name=user_params["dbname"],
-                    username=table_loader_params["username"],
                 )
 
         features_db_conninfo = make_conninfo(

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -128,7 +128,7 @@ def create_user(cursor, username: str, password: str) -> None:
                 "  END IF; "
                 "END "
                 "$$; "
-            ).format(username=sql.Identifier(username), password=password, user=username)
+            ).format(username=sql.Identifier(username), password=sql.Identifier(password), user=sql.Identifier(username))
         )
         print(f"DEBUG: SQL executed successfully")
 

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -123,15 +123,50 @@ def create_permissions(cursor, db_name: str, username: str) -> None:
         )
     )
 
+def create_table_loader_admin_permissions(cursor, db_name: str, username:str) -> None:
+    """Add admin permissions to the user to enable table editing for data ingestion"""
+    cursor.execute(
+        sql.SQL(
+            "GRANT CONNECT ON DATABASE {db_name} to {username};"
+            "GRANT CREATE ON DATABASE {db_name} to {username};"
+            "GRANT TEMPORARY ON DATABASE {db_name} to {username};"
+
+            # Allow table and sequence creation and editing for future objects
+            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {username};"
+            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {username};"
+            "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO {username};"
+
+            # Allow schema creation
+            "GRANT USAGE ON SCHEMA public TO {username};"
+            "GRANT CREATE ON SCHEMA public TO {username};"
+
+            # Allow table creation and editing
+            "GRANT ALL PRIVILEGES ON TABLES TO {username};"
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+
+            # Allow sequence creation and editing
+            "GRANT ALL PRIVILEGES ON SEQUENCES TO {username};"
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+
+            # Allows core data manipulation permissions on all existing tables with
+            # privileges to add data (insert), modify data (update), remove data (delete),
+            # and read data (select)
+            "GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA public TO {username};"
+            "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {username};"
+        ).format(
+            db_name=sql.Identifier(db_name),
+            username=sql.Identifier(username),
+        )
+    )
 
 def register_extensions(cursor) -> None:
     """Add PostGIS extension."""
     cursor.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS postgis;"))
-    
+
 
 def add_SRID_9311(cursor) -> None:
     """Add 9311 SRID to spatial_ref_sys"""
-    
+
     cursor.execute(sql.SQL(
         "INSERT INTO spatial_ref_sys (srid,auth_name,auth_srid,srtext,proj4text) VALUES (9311,'EPSG',9311,{srtext},{proj4text}) ON CONFLICT (srid) DO NOTHING;"
         ).format(
@@ -152,6 +187,7 @@ def handler(event, context):
         params = event["ResourceProperties"]
         connection_params = get_secret(params["conn_secret_arn"])
         user_params = get_secret(params["new_user_secret_arn"])
+        table_loader_params = get_secret(params["table_loader_user_secret_arn"])
 
         print("Connecting to admin DB...")
         admin_db_conninfo = make_conninfo(
@@ -183,6 +219,20 @@ def handler(event, context):
                     username=user_params["username"],
                 )
 
+                print("Creating admin user for table editing...")
+                create_user(
+                    cursor=cur,
+                    username=table_loader_params["username"],
+                    password=table_loader_params["password"],
+                )
+
+                print("Setting admin permissions...")
+                create_table_loader_admin_permissions(
+                    cursor=cur,
+                    db_name=user_params["dbname"],
+                    username=table_loader_params["username"],
+                )
+
         features_db_conninfo = make_conninfo(
             dbname=user_params["dbname"],
             user=connection_params["username"],
@@ -194,7 +244,7 @@ def handler(event, context):
             with conn.cursor() as cur:
                 print("Registering PostGIS ...")
                 register_extensions(cursor=cur)
-                
+
         with psycopg.connect(features_db_conninfo, autocommit=True) as conn:
             with conn.cursor() as cur:
                 print("Adding SRID 9311 ...")

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -127,9 +127,9 @@ def create_table_loader_admin_permissions(cursor, db_name: str, username:str) ->
     """Add admin permissions to the user to enable table editing for data ingestion"""
     cursor.execute(
         sql.SQL(
-            "GRANT CONNECT ON DATABASE {db_name} to {username};"
-            "GRANT CREATE ON DATABASE {db_name} to {username};"
-            "GRANT TEMPORARY ON DATABASE {db_name} to {username};"
+            "GRANT CONNECT ON DATABASE {db_name} TO {username};"
+            "GRANT CREATE ON DATABASE {db_name} TO {username};"
+            "GRANT TEMPORARY ON DATABASE {db_name} TO {username};"
 
             # Allow table and sequence creation and editing for future objects
             "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {username};"
@@ -141,12 +141,12 @@ def create_table_loader_admin_permissions(cursor, db_name: str, username:str) ->
             "GRANT CREATE ON SCHEMA public TO {username};"
 
             # Allow table creation and editing
-            "GRANT ALL PRIVILEGES ON TABLES TO {username};"
             "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "GRANT ALL PRIVILEGES ON TABLES TO {username};"
 
             # Allow sequence creation and editing
-            "GRANT ALL PRIVILEGES ON SEQUENCES TO {username};"
             "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+            "GRANT ALL PRIVILEGES ON SEQUENCES TO {username};"
 
             # Allows core data manipulation permissions on all existing tables with
             # privileges to add data (insert), modify data (update), remove data (delete),

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -86,6 +86,7 @@ def create_db(cursor, db_name: str) -> None:
 
 def create_user(cursor, username: str, password: str) -> None:
     """Create User."""
+
     cursor.execute(
         sql.SQL(
             "DO $$ "
@@ -220,6 +221,7 @@ def handler(event, context):
                 )
 
                 print("Creating admin user for table editing...")
+                print(f"Creating user: {table_loader_params['username']}")
                 create_user(
                     cursor=cur,
                     username=table_loader_params["username"],
@@ -227,6 +229,7 @@ def handler(event, context):
                 )
 
                 print("Setting admin permissions...")
+                print(f"Setting permissions for table loader user: {table_loader_params['username']}")
                 create_table_loader_admin_permissions(
                     cursor=cur,
                     db_name=user_params["dbname"],


### PR DESCRIPTION
**Ticket**: [Enable edits to existing tables (collections) when RDS restored from snapshot #16](https://github.com/NASA-IMPACT/veda-features-api-cdk/issues/16)

TLDR Testing : Used SM2A SIT and updated the VECTOR_SECRET to use my `veda-features-jt` credentials.

**Context**
At first, we suspected that the pipeline failures were due to PostgreSQL user permission issues. However, after further investigation, we discovered that the root cause was actually related to network connectivity. Specifically, the Airflow worker instances were unable to connect to the RDS database because their security groups were not allowed as inbound rules on the database (or RDS Proxy) security group. To resolve this, I updated our IAC for the features API to explicitly add the Airflow workers security groups as allowed inbound sources. This change enabled the Airflow DAGs `vector-eis-fedsoutput-lfarchive`,` vector-eis-fedsoutput-snapshot`, and `veda_ingest_vector` to successfully connect to the database and run as expected. 

**Testing Instructions**
To test this yourself, you can use [sm2a SIT](https://sm2a.sit.openveda.cloud/) which is set to use my test stack (jt-test) for features and trigger any three of the DAGs mentioned above. 