### PR TITLE
fix: metrics and traces not broadcasting properly

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -51,23 +51,6 @@ runs:
         python -m pip install -r requirements.txt
         python -m pip install boto3
 
-    - name: Launch services
-      shell: bash
-      working-directory: ${{ inputs.dir }}
-      run: docker compose up --build -d
-
-    - name: Sleep for 10 seconds
-      run: sleep 10s
-      shell: bash
-      working-directory: ${{ inputs.dir }}
-
-    - name: Stop services
-      shell: bash
-      working-directory: ${{ inputs.dir }}
-      run: |
-        docker compose down --rmi all --volumes
-        sudo rm -rf .pgdata
-
     - name: Get relevant environment configuration from aws secrets
       shell: bash
       working-directory: ${{ inputs.dir }}

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -10,7 +10,7 @@ from tipg.factory import Endpoints
 from tipg.middleware import CacheControlMiddleware, CatalogUpdateMiddleware
 from tipg.settings import CustomSQLSettings, DatabaseSettings
 
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
 
@@ -55,17 +55,24 @@ app = FastAPI(
     docs_url="/docs",
     lifespan=lifespan,
     root_path=settings.root_path,
-    route_class=LoggerRouteHandler,
 )
 
 ogc_api = Endpoints(
     title=settings.name,
     with_tiles_viewer=settings.add_tiles_viewer,
 )
-ogc_api.router.route_class = LoggerRouteHandler
-
 app.include_router(ogc_api.router)
-app.router.route_class = LoggerRouteHandler
+
+# `ogc_api.router` has subrouters that need the LoggerRouteHandler class to be applied.
+# This function recursively applies the LoggerRouteHandler to all routes in the router.
+def apply_route_class(router: APIRouter, route_class):
+    for route in router.routes:
+        if hasattr(route, "route_class"):
+            route.route_class = route_class
+        if hasattr(route, "router"):
+            apply_route_class(route.router, route_class)
+
+apply_route_class(app, LoggerRouteHandler)
 
 app.add_middleware(
     CORSMiddleware,

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -55,12 +55,15 @@ app = FastAPI(
     docs_url="/docs",
     lifespan=lifespan,
     root_path=settings.root_path,
+    route_class=LoggerRouteHandler,
 )
 
 ogc_api = Endpoints(
     title=settings.name,
     with_tiles_viewer=settings.add_tiles_viewer,
 )
+ogc_api.router.route_class = LoggerRouteHandler
+
 app.include_router(ogc_api.router)
 app.router.route_class = LoggerRouteHandler
 

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, FastAPI, Request
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
 
-from src.monitoring import LoggerRouteHandler
+from src.monitoring import ObservabilityMiddleware
 
 settings = APISettings()
 postgres_settings = settings.load_postgres_settings()
@@ -63,17 +63,6 @@ ogc_api = Endpoints(
 )
 app.include_router(ogc_api.router)
 
-# `ogc_api.router` has subrouters that need the LoggerRouteHandler class to be applied.
-# This function recursively applies the LoggerRouteHandler to all routes in the router.
-def apply_route_class(router: APIRouter, route_class):
-    for route in router.routes:
-        if hasattr(route, "route_class"):
-            route.route_class = route_class
-        if hasattr(route, "router"):
-            apply_route_class(route.router, route_class)
-
-apply_route_class(app, LoggerRouteHandler)
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
@@ -89,6 +78,7 @@ app.add_middleware(
     ttl=settings.catalog_ttl,
     db_settings=db_settings,
 )
+app.add_middleware(ObservabilityMiddleware)
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 

--- a/features_api/runtime/src/monitoring.py
+++ b/features_api/runtime/src/monitoring.py
@@ -1,13 +1,10 @@
-"""Observability utils"""
 import json
-from typing import Callable
+from typing import Callable, Optional
 
 from aws_lambda_powertools import Logger, Metrics, Tracer, single_metric
-from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
-from src.config import FeaturesAPISettings
+from aws_lambda_powertools.metrics import MetricUnit
 
-from fastapi import Request, Response
-from fastapi.routing import APIRoute
+from src.config import FeaturesAPISettings
 
 settings = FeaturesAPISettings()
 
@@ -17,45 +14,121 @@ metrics.set_default_dimensions(environment=settings.stage, service="features-api
 tracer: Tracer = Tracer()
 
 
-class LoggerRouteHandler(APIRoute):
-    """Extension of base APIRoute to add context to log statements, as well as record usage metrics"""
+class ObservabilityMiddleware:
 
-    def get_route_handler(self) -> Callable:
-        """Overide route handler method to add logs, metrics, tracing"""
-        original_route_handler = super().get_route_handler()
+    def __init__(self, app: Callable):
+        self.app = app
 
-        async def route_handler(request: Request) -> Response:
-            # Add fastapi context to logs
-            body = await request.body()
+    async def __call__(self, scope, receive, send):
+        # Only handle HTTP requests
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method: str = scope.get("method", "GET")
+        raw_path: str = scope.get("path", "")
+
+        # --- Buffer the incoming body so we can log it but still pass it downstream ---
+        body = b""
+        more_body = True
+
+        # Consume the body from the original receive channel
+        while more_body:
+            message = await receive()
+            if message["type"] != "http.request":
+                # Pass through non-http.request messages
+                await self.app(scope, _make_receive_replay([message]), send)
+                return
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        # Prepare a receive wrapper that replays the buffered body to the app
+        receive_replayed = _make_receive_replay([
+            {"type": "http.request", "body": body, "more_body": False}
+        ])
+
+        # Try to parse JSON body for structured logging (non-JSON becomes None)
+        body_json = None
+        if body:
             try:
                 body_json = json.loads(body)
-            except json.decoder.JSONDecodeError:
+            except json.JSONDecodeError:
                 body_json = None
 
-            ctx = {
-                "path": request.url.path,
-                "path_params": request.path_params,
-                "body": body_json,
-                "route": self.path,
-                "method": request.method,
-            }
-            logger.append_keys(fastapi=ctx)
-            logger.info("Received request")
+        # Initial context logging (route template not yet resolved here)
+        ctx = {
+            "path": raw_path,
+            "method": method,
+            "path_params": None,  # will try to resolve after routing
+            "route": None,        # will try to resolve after routing
+            "body": body_json,
+        }
+        logger.append_keys(fastapi=ctx)
+        logger.info("Received request")
 
-            with single_metric(
-                name="RequestCount",
-                unit=MetricUnit.Count,
-                value=1,
-                default_dimensions=metrics.default_dimensions,
-                namespace="veda-backend",
-            ) as metric:
-                metric.add_dimension(
-                    name="route", value=f"{request.method} {self.path}"
-                )
+        # Add X-Ray annotations early
+        tracer.put_annotation(key="path", value=raw_path)
+        tracer.put_annotation(key="method", value=method)
 
-            tracer.put_annotation(key="path", value=request.url.path)
-            tracer.capture_method(original_route_handler)(request)
+        # Capture status code via send wrapper
+        status_holder = {"status": 500}
 
-            return await original_route_handler(request)
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                status_holder["status"] = message.get("status", 500)
+            await send(message)
 
-        return route_handler
+        # Route/execute the request with tracing around the app call
+        @tracer.capture_method
+        async def _call_downstream():
+            await self.app(scope, receive_replayed, send_wrapper)
+
+        await _call_downstream()
+
+        # After downstream handled routing, try to resolve route template & path params
+        route_template: Optional[str] = None
+        path_params = None
+        route_obj = scope.get("route")
+        if route_obj is not None:
+            # FastAPI/Starlette exposes a path_format like "/items/{item_id}"
+            route_template = getattr(route_obj, "path_format", None) or getattr(route_obj, "path", None)
+        path_params = scope.get("path_params", None)
+
+        # Update log context with resolved info and status
+        final_ctx = {
+            "path": raw_path,
+            "method": method,
+            "path_params": path_params,
+            "route": route_template or raw_path,
+            "status_code": status_holder["status"],
+            "body": body_json,
+        }
+        logger.append_keys(fastapi=final_ctx)
+        logger.info("Completed request")
+
+        # Emit metric with default + route dimension
+        dim_route_value = f"{method} {route_template or raw_path}"
+        with single_metric(
+            name="RequestCount",
+            unit=MetricUnit.Count,
+            value=1,
+            default_dimensions=metrics.default_dimensions,
+            namespace="veda-backend",
+        ) as metric:
+            metric.add_dimension(name="route", value=dim_route_value)
+            metric.add_dimension(name="status_code", value=str(status_holder["status"]))
+
+
+def _make_receive_replay(messages):
+    """
+    Build a 'receive' callable that replays given ASGI messages once.
+    """
+    async def _receive():
+        if _receive._idx < len(messages):
+            msg = messages[_receive._idx]
+            _receive._idx += 1
+            return msg
+        # No more data
+        return {"type": "http.request", "body": b"", "more_body": False}
+    _receive._idx = 0  # type: ignore[attr-defined]
+    return _receive

--- a/features_api/runtime/src/monitoring.py
+++ b/features_api/runtime/src/monitoring.py
@@ -1,25 +1,24 @@
 """Observability utils"""
+import json
 from typing import Callable
 
-from aws_lambda_powertools import Logger, Metrics, Tracer
+from aws_lambda_powertools import Logger, Metrics, Tracer, single_metric
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
+from src.config import FeaturesAPISettings
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
 
-from src.config import FeaturesAPISettings as APISettings
-
-settings = APISettings()
+settings = FeaturesAPISettings()
 
 logger: Logger = Logger(service="features-api", namespace="veda-backend")
-metrics: Metrics = Metrics(service="features-api", namespace="veda-backend")
+metrics: Metrics = Metrics(namespace="veda-backend")
 metrics.set_default_dimensions(environment=settings.stage, service="features-api")
 tracer: Tracer = Tracer()
 
 
-
 class LoggerRouteHandler(APIRoute):
-    """Extension of base APIRoute to add context to log statements, as well as record usage metricss"""
+    """Extension of base APIRoute to add context to log statements, as well as record usage metrics"""
 
     def get_route_handler(self) -> Callable:
         """Overide route handler method to add logs, metrics, tracing"""
@@ -27,22 +26,36 @@ class LoggerRouteHandler(APIRoute):
 
         async def route_handler(request: Request) -> Response:
             # Add fastapi context to logs
+            body = await request.body()
+            try:
+                body_json = json.loads(body)
+            except json.decoder.JSONDecodeError:
+                body_json = None
+
             ctx = {
                 "path": request.url.path,
+                "path_params": request.path_params,
+                "body": body_json,
                 "route": self.path,
                 "method": request.method,
             }
             logger.append_keys(fastapi=ctx)
             logger.info("Received request")
-            metrics.add_metric(
-                name="/".join(
-                    str(request.url.path).split("/")[:2]
-                ),  # enough detail to capture search IDs, but not individual tile coords
+
+            with single_metric(
+                name="RequestCount",
                 unit=MetricUnit.Count,
                 value=1,
-            )
+                default_dimensions=metrics.default_dimensions,
+                namespace="veda-backend",
+            ) as metric:
+                metric.add_dimension(
+                    name="route", value=f"{request.method} {self.path}"
+                )
+
             tracer.put_annotation(key="path", value=request.url.path)
             tracer.capture_method(original_route_handler)(request)
+
             return await original_route_handler(request)
 
         return route_handler


### PR DESCRIPTION
Fixes #19 

We had added functionality to collect metrics and improve logs for requests to this API, in alignment with our `veda-backend` services. However, `tipg` uses nested routers that did not have our custom router class properly applied. I've converted the functionality of this router class to a middleware that allows us to collect metrics from OGC API requests. This is currently deployed to `dev.openveda.cloud/api/features`.

This may not fix the "message too long" errors we had been seeing, but it will make it easier to debug.

I also sped up CI by removing a copy-pasted docker compose step - we have no tests to run, and so this step just delays deployments.