### PR TITLE
fix: upgrade python version

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
-        python-version: '3.9'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: |
           ${{ inputs.dir }}/requirements.txt

--- a/Dockerfile.features.local
+++ b/Dockerfile.features.local
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 
 FROM ghcr.io/vincentsarago/uvicorn-gunicorn:${PYTHON_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo hosts both runtime and infrastructure for veda-features-api.
 Run the docker-compose:
 
 ```
-docker-compose up --build 
+docker compose up --build 
 ```
 
 ## Deployment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - $HOME/.aws/credentials:/root/.aws/credentials
 
   database:
-    container_name: veda.db
+    container_name: veda.tipgdb
     platform: linux/amd64
     image: ghcr.io/stac-utils/pgstac:v0.7.10
     environment:

--- a/features_api/infrastructure/construct.py
+++ b/features_api/infrastructure/construct.py
@@ -45,7 +45,7 @@ class FeaturesAPILambdaConstruct(Construct):
         features_api_function = aws_lambda.Function(
             self,
             "lambda",
-            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            runtime=aws_lambda.Runtime.PYTHON_3_12,
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="features_api/runtime/Dockerfile",

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
-RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
+RUN pip install "mangum>=0.17,<0.18" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -9,6 +9,7 @@ RUN rm -rf /tmp/features
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
 RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+# We have temporarily removed this line due to a Mangum installation problem; recheck on next version upgrade
 # RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
-RUN pip install mangum  /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
+RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -3,13 +3,13 @@ FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
-RUN pip install "mangum>=0.17,<0.18" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
+RUN pip install "mangum" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
 RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+# RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
-RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
+RUN pip install "mangum" /tmp/features["psycopg-binary"] -t /asset --no-binary pydantic
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api/runtime/Dockerfile
+++ b/features_api/runtime/Dockerfile
@@ -1,9 +1,9 @@
-FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.9:latest
+FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 
 WORKDIR /tmp
 
 COPY features_api/runtime /tmp/features
-RUN pip install "mangum>=0.14,<0.15" /tmp/features["psycopg-binary"] -t /asset --no-binary pydantic
+RUN pip install mangum  /tmp/features["psycopg-binary"] /tmp/features -t /asset --no-binary pydantic
 RUN rm -rf /tmp/features
 
 # Reduce package size and remove useless files

--- a/features_api/runtime/setup.py
+++ b/features_api/runtime/setup.py
@@ -26,7 +26,7 @@ extra_reqs = {
 setup(
     name="veda.features_api",
     description="",
-    python_requires=">=3.9",
+    python_requires=">=3.12",
     packages=find_namespace_packages(exclude=["tests*"]),
     zip_safe=False,
     install_requires=inst_reqs,

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -46,7 +46,7 @@ class BootstrapTIPG(Construct):
             self,
             "lambda",
             handler="handler.handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            runtime=aws_lambda.Runtime.PYTHON_3_12,
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath("./"),
                 file="features_api_database/runtime/Dockerfile",

--- a/features_api_database/runtime/Dockerfile
+++ b/features_api_database/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.9:latest
+FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
 
 WORKDIR /tmp
 


### PR DESCRIPTION
## what
This PR updates the python version in lambdas ahead of the deprecation of python 3.9 lambda images later this year (https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html).

**Note** We also commented a [cleanup line](https://github.com/NASA-IMPACT/veda-features-api-cdk/pull/44/files#diff-1ca678efbde980a87a2f4821306e82c1115b55ee1b3d895ddb7c3edaae308301R12) from the Dockerfile to resolve error  `Runtime.ImportModuleError: Unable to import module 'handler': cannot import name 'Mangum' from 'mangum' (unknown location)
Traceback (most recent call last):`. It is not clear why this was needed for this python 3.12 lambda and not other similar lambdas in the backend stack so this should be revisited when python is updated to 3.13.

## issue
#41

## testing
Manually deployed changes to the dev stack and 
- tested various endpoints manually
- confirmed that sm2a scheduled ingests ran as expected