### PR TITLE
Remove broken startup code

### DIFF
--- a/features_api/runtime/handler.py
+++ b/features_api/runtime/handler.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from mangum import Mangum
-from src.app import app
+from src.app import app, startup
 from src.monitoring import logger, metrics, tracer
 
 logging.getLogger("mangum.lifespan").setLevel(logging.DEBUG)
@@ -14,8 +14,7 @@ logging.getLogger("mangum.http").setLevel(logging.DEBUG)
 handler = Mangum(app, lifespan="off")
 if "AWS_EXECUTION_ENV" in os.environ:
     loop = asyncio.get_event_loop()
-    for startup_handler in app.router.on_startup:
-        loop.run_until_complete(startup_handler())
+    loop.run_until_complete(startup(app))
 
 # Add tracing
 handler.__name__ = "handler"  # tracer requires __name__ to be set

--- a/features_api/runtime/handler.py
+++ b/features_api/runtime/handler.py
@@ -11,9 +11,11 @@ from src.monitoring import logger, metrics, tracer
 logging.getLogger("mangum.lifespan").setLevel(logging.DEBUG)
 logging.getLogger("mangum.http").setLevel(logging.DEBUG)
 
-# lifespan="on" in Mangum handles the startup/shutdown
-handler = Mangum(app, lifespan="on")
-
+handler = Mangum(app, lifespan="off")
+if "AWS_EXECUTION_ENV" in os.environ:
+    loop = asyncio.get_event_loop()
+    for startup_handler in app.router.on_startup:
+        loop.run_until_complete(startup_handler())
 
 # Add tracing
 handler.__name__ = "handler"  # tracer requires __name__ to be set

--- a/features_api/runtime/handler.py
+++ b/features_api/runtime/handler.py
@@ -11,11 +11,9 @@ from src.monitoring import logger, metrics, tracer
 logging.getLogger("mangum.lifespan").setLevel(logging.DEBUG)
 logging.getLogger("mangum.http").setLevel(logging.DEBUG)
 
+# lifespan="on" in Mangum handles the startup/shutdown
 handler = Mangum(app, lifespan="on")
 
-if "AWS_EXECUTION_ENV" in os.environ:
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(app.router.startup())
 
 # Add tracing
 handler.__name__ = "handler"  # tracer requires __name__ to be set

--- a/features_api/runtime/src/app.py
+++ b/features_api/runtime/src/app.py
@@ -1,8 +1,13 @@
 """feature services fastapi"""
-from contextlib import asynccontextmanager
-import os
 
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import APIRouter, FastAPI, Request
 from src.config import FeaturesAPISettings as APISettings
+from src.monitoring import ObservabilityMiddleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette_cramjam.middleware import CompressionMiddleware
 from tipg import __version__ as tipg_version
 from tipg.collections import register_collection_catalog
 from tipg.database import close_db_connection, connect_to_db
@@ -11,49 +16,36 @@ from tipg.factory import Endpoints
 from tipg.middleware import CacheControlMiddleware, CatalogUpdateMiddleware
 from tipg.settings import CustomSQLSettings, DatabaseSettings
 
-from fastapi import APIRouter, FastAPI, Request
-from starlette.middleware.cors import CORSMiddleware
-from starlette_cramjam.middleware import CompressionMiddleware
-
-from src.monitoring import ObservabilityMiddleware
-
 settings = APISettings()
 postgres_settings = settings.load_postgres_settings()
-db_settings = DatabaseSettings(
-    datetime_extent=False,
-    spatial_extent=False
-)
-custom_sql_settings = CustomSQLSettings()
+db_settings = DatabaseSettings(datetime_extent=False, spatial_extent=False)
 
-# Path to custom sql directory
 APP_DIR = os.path.dirname(os.path.abspath(__file__))
 SQL_DIR = os.path.join(APP_DIR, "..", "sql")
-
 custom_sql_settings = CustomSQLSettings(
     custom_sql_directory=SQL_DIR,
 )
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """reload catalogs"""
+
+async def startup(app: FastAPI):
+    """Run startup tasks - connect to DB and register collection catalog."""
     await connect_to_db(
         app,
-        schemas=[
-            "public",
-        ],
+        schemas=["public"],
         user_sql_files=custom_sql_settings.sql_files,
         settings=postgres_settings,
     )
-
-    # Register Collection Catalog
     await register_collection_catalog(
         app,
         db_settings=db_settings,
     )
 
-    yield
 
-    # Close the Connection Pool
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage application lifespan."""
+    await startup(app)
+    yield
     await close_db_connection(app)
 
 
@@ -106,8 +98,7 @@ def ping():
 
 @app.get("/refresh")
 async def refresh(request: Request):
-    """refresh catalog"""
-    
+    """Refresh catalog."""
     await register_collection_catalog(
         request.app,
         db_settings=db_settings,


### PR DESCRIPTION
Changes:
- Set lifespan="off" on Mangum to prevent it from re-running the lifecycle on every invocation
- Extracted startup logic from the lifespan context manager into a standalone startup() coroutine in app.py, allowing it to be called directly from handler.py at cold start without relying on app.router.on_startup (which is empty when using the lifespan pattern) or entering the lifespan context manager