### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,6 @@
 name: CDK Deploy Dev Workflow 🚀
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -34,6 +33,8 @@ jobs:
     needs: [define-environment]
     environment: ${{ needs.define-environment.outputs.env_name }}
     concurrency: ${{ needs.define-environment.outputs.env_name }}
+    permissions:
+      id-token: write # Required to request OIDC token for use with AWS
 
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Dependabot 
Dependabot **security** updates are already enabled, this config will automate **version** updates. We likely won't find the right alert:noise balance on the first attempt, so we should be open to further tuning.

Config covers:

- `pip` (CDK build)
- `docker` (API container image)
- `github-actions` (CI)

#### Schedule
Currently on the default schedule, so we'd get in batches all at once, but can spread out more if that's the preference.

#### Cooldowns
Also used more granular cooldown configs for major/minor version bumps on `uv` only, but can add to other package ecosystems if that's preferred as well. [Some suggest up to 14 days](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns), but we also had a teammember get blocked on patching.a security fix, so attempting to balance.

## OSSF Scorecard

From the Open Source Security Foundation. Audits repository security posture, practices, and config.

https://scorecard.dev/
https://github.com/ossf/scorecard-action

#### Schedule

Alongside pushes to main, also runs Monday 10:30/11:30 CT to ensure consistent assessment. Time was chosen to run before Monday tagup, but can absolutely be changed.

## Token permissions

Moved `id-token: write` from top-level (all jobs) to specific job required.