### PR TITLE
fix: rds bootstrap

### DIFF
--- a/features_api_database/infrastructure/config.py
+++ b/features_api_database/infrastructure/config.py
@@ -99,6 +99,10 @@ class FeaturesDBSettings(BaseSettings):
         False,
         description="Boolean if the RDS should be encrypted",
     )
+    rds_deletion_protection: Optional[bool] = Field(
+        True,
+        description="Config to temporarily disable deletion protection for certain maintenance operations. Be sure to reenable after work is complete.",
+    )
     max_allocated_storage: Optional[int] = Field(
         500,
         description="Upper limit to which RDS can scale the storage in GiB(Gibibyte)",

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -180,7 +180,7 @@ class FeaturesRdsConstruct(Construct):
             "engine": engine,
             "instance_type": rds_instance_type,
             "vpc_subnets": self.vpc_subnets,
-            "deletion_protection": True,
+            "deletion_protection": features_db_settings.rds_deletion_protection,
             "removal_policy": RemovalPolicy.RETAIN,
             "publicly_accessible": features_db_settings.publicly_accessible,
             "parameter_group": parameter_group,

--- a/features_api_database/infrastructure/construct.py
+++ b/features_api_database/infrastructure/construct.py
@@ -181,7 +181,7 @@ class FeaturesRdsConstruct(Construct):
             "instance_type": rds_instance_type,
             "vpc_subnets": self.vpc_subnets,
             "deletion_protection": features_db_settings.rds_deletion_protection,
-            "removal_policy": RemovalPolicy.RETAIN,
+            "removal_policy": RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
             "publicly_accessible": features_db_settings.publicly_accessible,
             "parameter_group": parameter_group,
         }

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -128,7 +128,7 @@ def create_user(cursor, username: str, password: str) -> None:
                 "  END IF; "
                 "END "
                 "$$; "
-            ).format(username=sql.Identifier(username), password=sql.Identifier(password), user=sql.Identifier(username))
+            ).format(username=sql.Identifier(username), password=password, user=username)
         )
         print(f"DEBUG: SQL executed successfully")
 

--- a/features_api_database/runtime/handler.py
+++ b/features_api_database/runtime/handler.py
@@ -107,29 +107,24 @@ def create_user(cursor, username: str, password: str) -> None:
 
     try:
         # Check if user exists before
-        cursor.execute("SELECT rolname FROM pg_roles WHERE rolname = %s", (username,))
-        exists_before = cursor.fetchone() is not None
+        cursor.execute("SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = %s)", (username,))
+        exists_before = cursor.fetchone()[0]
         print(f"DEBUG: User '{username}' exists before: {exists_before}")
 
         # Create/update user
-        cursor.execute(
-            sql.SQL(
-                "DO $$ "
-                "BEGIN "
-                "  IF NOT EXISTS ( "
-                "       SELECT 1 FROM pg_roles "
-                "       WHERE rolname = {user}) "
-                "  THEN "
-                "    CREATE USER {username} "
-                "    WITH PASSWORD {password}; "
-                "  ELSE "
-                "    ALTER USER {username} "
-                "    WITH PASSWORD {password}; "
-                "  END IF; "
-                "END "
-                "$$; "
-            ).format(username=sql.Identifier(username), password=password, user=username)
-        )
+        if exists_before:
+            cursor.execute(
+                sql.SQL(
+                    "ALTER USER {username} WITH PASSWORD {password};"
+                ).format(username=sql.Identifier(username), password=password)
+            )
+        else:
+            cursor.execute(
+                sql.SQL(
+                    "CREATE USER {username} WITH PASSWORD {password};"
+                ).format(username=sql.Identifier(username), password=password)
+            )
+
         print(f"DEBUG: SQL executed successfully")
 
         # Check if user exists after


### PR DESCRIPTION
**Summary:**

Addresses issues surfaced during [initial stack create on EIC](https://github.com/NASA-IMPACT/veda-architecture/issues/780): 

- Syntax error in bootstrapper SQL command to create non-superuser
- Rollback failure on RDS-dependent resources

## Changes

* SQL syntax error
    * Reverted `Identifier` use on non-identifier parameters
    * Break up command + use one role exists check
        * `Identifier` use caught the `CREATE USER` condition in update command
* Rollback failure
    * Make deletion protection configurable, defaulting to True
        * Useful for other database maintenance procedures
    * Allow database rollback on failed create with `RETAIN_ON_UPDATE_OR_DELETE`

## PR Checklist

- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
- [ ] Infrastructure changes - test using `terraform validate` and `terraform plan`